### PR TITLE
Fix the command line options

### DIFF
--- a/astro
+++ b/astro
@@ -259,12 +259,6 @@ EOF
 # Execution
 export LESS='-P Keys\: qgrbosHmM, to see a description run astro -h'
 
-# Save terminal
-tput smcup
-
-# Restore terminal
-trap "tput rmcup && exit" EXIT SIGINT SIGHUP
-
 # Parse arguments
 args="$*"
 case "$args" in
@@ -277,6 +271,12 @@ case "$args" in
 		exit
 		;;
 esac
+
+# Save terminal
+tput smcup
+
+# Restore terminal
+trap "tput rmcup && exit" EXIT SIGINT SIGHUP
 
 # Configuration
 [ -n "$HOME/.config/astro" ] && mkdir -p "$HOME/.config/astro"


### PR DESCRIPTION
Looks like the smcup sequence stores and removes any arguments with
leading dashes. Didn't find any documentation of this anywhere so it
might as well be something else. At least this way both the options
and the hostname argument work.