### PR TITLE
Replace `\e` with `\033`

### DIFF
--- a/astro
+++ b/astro
@@ -91,7 +91,7 @@ fetch() {
 	[ "$debug" ] && echo "Text width: $width" >&2
 
 	[ "$debug" ] && echo "Requesting $1://$2:$3/$4$5" >&2
-	printf '\e]2;%s\007' "astro: $2/$4"
+	printf '\033]2;%s\007' "astro: $2/$4"
 	echo "$1://$2:$3/$4$5" | openssl s_client \
 		-connect "$2:$3" -crlf -quiet \
 		-ign_eof 2> /dev/null | {
@@ -190,10 +190,10 @@ fetch() {
 				printf '%*s%s\n' "$margin" "" "$line"
 			else
 				case "$line" in
-					"### "*) sty='\e[35;1m' && line="$(echo "$line" | cut -c 5- )" ;;
-					"## "*) sty='\e[35;4m' && line="$(echo "$line" | cut -c 4-)" ;;
-					"# "*) sty='\e[35;4;1m' && line="$(echo "$line" | cut -c 3-)" ;;
-					"> "*) sty='  \e[2;3m' && line="$(echo "$line" | cut -c 3-)" ;;
+					"### "*) sty='\033[35;1m' && line="$(echo "$line" | cut -c 5- )" ;;
+					"## "*) sty='\033[35;4m' && line="$(echo "$line" | cut -c 4-)" ;;
+					"# "*) sty='\033[35;4;1m' && line="$(echo "$line" | cut -c 3-)" ;;
+					"> "*) sty='  \033[2;3m' && line="$(echo "$line" | cut -c 3-)" ;;
 					"=>"*)
 						link="$(echo "$line" | sed -e 's/^=> *\(\S\+\)\(\s*.*\)/\1 \2/g')"
 						echo "$link" >> "$cachedir/links.txt"
@@ -201,10 +201,10 @@ fetch() {
 						# shellcheck disable=SC2086
 						line="$(echo $link | cut -d' ' -f2-)"
 						[ -z "$line" ] && line="$link"
-						sty='\e[36;3m'
-						line="\\e[35m=>\\e[36;3m $line"
+						sty='\033[36;3m'
+						line="\\033[35m=>\\033[36;3m $line"
 						;;
-					'* '*) sty="" && line="\\e[35;1m •\\e[0m$(echo "$line" | cut -c 2-)";;
+					'* '*) sty="" && line="\\033[35;1m •\\033[0m$(echo "$line" | cut -c 2-)";;
 					*) sty="";;
 				esac
 				echo "$line" | fold -w $width -s | {


### PR DESCRIPTION
`\e` works with bash and other shells, but since its not a standard,
when I try with dash (the POSIX sh I use), it breaks and prints the raw
string. `\033` seems to be a standard accepted by all programs.