### PR TITLE
Add possibility to change styles/colors on config

### DIFF
--- a/astro
+++ b/astro
@@ -192,10 +192,10 @@ fetch() {
 				printf '%*s%s\n' "$margin" "" "$line"
 			else
 				case "$line" in
-					"### "*) sty='\033[35;1m' && line="$(echo "$line" | cut -c 5- )" ;;
-					"## "*) sty='\033[35;4m' && line="$(echo "$line" | cut -c 4-)" ;;
-					"# "*) sty='\033[35;4;1m' && line="$(echo "$line" | cut -c 3-)" ;;
-					"> "*) sty='  \033[2;3m' && line="$(echo "$line" | cut -c 3-)" ;;
+					"### "*) sty="$sty_header3" && line="$(echo "$line" | cut -c 5- )" ;;
+					"## "*) sty="$sty_header2" && line="$(echo "$line" | cut -c 4-)" ;;
+					"# "*) sty="$sty_header1" && line="$(echo "$line" | cut -c 3-)" ;;
+					"> "*) sty="  $sty_quote" && line="$(echo "$line" | cut -c 3-)" ;;
 					"=>"*)
 						link="$(echo "$line" | sed -e 's/^=> *\(\S\+\)\(\s*.*\)/\1 \2/g')"
 						echo "$link" >> "$cachedir/links.txt"
@@ -203,10 +203,10 @@ fetch() {
 						# shellcheck disable=SC2086
 						line="$(echo $link | cut -d' ' -f2-)"
 						[ -z "$line" ] && line="$link"
-						sty='\033[36;3m'
-						line="\\033[35m=>\\033[36;3m $line"
+						sty="$sty_linkt"
+						line="$sty_linkb=>$sty_linkt $line"
 						;;
-					'* '*) sty="" && line="\\033[35;1m •\\033[0m$(echo "$line" | cut -c 2-)";;
+					'* '*) sty="" && line=" $sty_listb•$sty_listt$(echo "$line" | cut -c 2-)";;
 					*) sty="";;
 				esac
 				echo "$line" | fold -w $width -s | {
@@ -320,11 +320,37 @@ if [ -e "$configfile" ]
 then
 	margin="$(grep margin "$configfile" | cut -d '=' -f 2,3)"
 	homepage="$(grep homepage "$configfile" | cut -d '=' -f 2,3)"
+	sty_header1="$(grep style-header1 "$configfile" | cut -d '=' -f 2-)"
+	sty_header2="$(grep style-header2 "$configfile" | cut -d '=' -f 2-)"
+	sty_header3="$(grep style-header3 "$configfile" | cut -d '=' -f 2-)"
+	sty_quote="$(grep style-quote "$configfile" | cut -d '=' -f 2-)"
+	sty_linkb="$(grep style-link-bullet "$configfile" | cut -d '=' -f 2-)"
+	sty_linkt="$(grep style-link-text "$configfile" | cut -d '=' -f 2-)"
+	sty_listb="$(grep style-list-bullet "$configfile" | cut -d '=' -f 2-)"
+	sty_listt="$(grep style-list-text "$configfile" | cut -d '=' -f 2-)"
 fi
 
 # Default values
 [ -z "$margin" ] && margin=8
 [ -z "$homepage" ] && homepage="gemini.circumlunar.space/"
+[ -z "$sty_header1" ] && sty_header1='35;4;1'
+[ -z "$sty_header2" ] && sty_header2='35;4'
+[ -z "$sty_header3" ] && sty_header3='35;1'
+[ -z "$sty_quote" ] && sty_quote='2;3'
+[ -z "$sty_linkb" ] && sty_linkb='35'
+[ -z "$sty_linkt" ] && sty_linkt='36;3'
+[ -z "$sty_listb" ] && sty_listb='35;1'
+[ -z "$sty_listt" ] && sty_listt='0'
+
+# ANSI style code
+sty_header1="\\033[${sty_header1}m"
+sty_header2="\\033[${sty_header2}m"
+sty_header3="\\033[${sty_header3}m"
+sty_quote="\\033[${sty_quote}m"
+sty_linkb="\\033[${sty_linkb}m"
+sty_linkt="\\033[${sty_linkt}m"
+sty_listb="\\033[${sty_listb}m"
+sty_listt="\\033[${sty_listt}m"
 
 [ -e "$debug" ] && {
 	echo "Starting with ${args:-$homepage}"


### PR DESCRIPTION
This commit adds the following lines in the configuration file:

- `style-header1` (default `36;4;1`)
- `style-header2` (default `35;4`)
- `style-header3` (default `35;1`)
- `style-quote` (default `2;3`)
- `style-link-bullet` (default `35`)
- `style-link-text` (default `36;3`)
- `style-list-bullet` (default `35;1`)
- `style-list-text` (default `0`)

The `ESC[` and `m` bits of the ANSI code are added inside the code.

What do you think? I know this feature can add a lot of things that weren't planned, so I'll understand any kind of feedback.