### PR TITLE
Update Makefile to use install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@
 PREFIX ?= ~/.local
 
 install:
-	cp astro $(PREFIX)/bin/
+	install -m +x astro -d $(PREFIX)/bin
 


### PR DESCRIPTION
As discussed in #16 this replaces `cp` with `install`. Both are stdutils, but `install` will handle a whole bunch of edgecases, like creating nested folders, ensuring the right permissions on the file, and so on.