### PR TITLE
tweak URL parse regex to better handle missing schema

### DIFF
--- a/astro
+++ b/astro
@@ -58,7 +58,7 @@ parseurl() {
 	# shellcheck disable=SC2154
 	[ "$debug" ] && echo "Parsing: $1" >&2 && sleep 2
 	IFS='|' read -r proto hostport path rest << EOF
-$(echo "$1" | sed -E 's@^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?@\2\|\4\|\5\|\7@g')
+$(echo "$1" | sed -E 's@^(([^:/?#]+):)?(/?/?([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?@\2\|\4\|\5\|\7@g')
 EOF
 
 	[ "$debug" ] && echo "Parsed URL: proto: $proto host: $hostport path: $path" >&2 && sleep 2


### PR DESCRIPTION
Tweak the regular expression used for parsing URLS so that this case is handled properly:

```
astro derelict.garden/astro.gmi
```

Fixes #19.

I don't know if this is the _best_ fix, but it seems to cover all the cases for me.