### PR TITLE
add K command to delete bookmark for the current URL

### DIFF
--- a/astro
+++ b/astro
@@ -19,6 +19,7 @@ usage() {
 	echo "  H	go to homepage"
 	echo "  m	add bookmark"
 	echo "  M	go to a bookmark"
+	echo "  K	remove bookmark for current url"
 	echo ""
 	echo "Examples:"
 	echo "  astro		Start browsing the default webpage"
@@ -85,7 +86,8 @@ cachedir="$cachehome/astro"
 # H (53): go to homepage
 # m (54): add page to bookmarks
 # M (55): go to a bookmark
-[ -n "$LESSKEY" ] && echo "AE0rR2MjAG8AmDEAcgCYMgBnAJgzAGIAmDQASACYNQBtAJg2AE0AmDcAZQAAdgAAeEVuZA==" | \
+# K (56): remove bookmark for current url
+[ -n "$LESSKEY" ] && echo "AE0rR2MoAG8AmDEAcgCYMgBnAJgzAGIAmDQASACYNQBtAJg2AE0AmDcASwCYOABlAAB2AAB4RW5k" | \
 	base64 -d  > "$LESSKEY"
 
 if [ ! -s "$configfile" ]
@@ -396,13 +398,19 @@ EOF
 			printf "Enter link number: "
 			read -r i <&1
 			url="$(sed "${i}q;d" "$bookmarkfile" | cut -d' ' -f1)"
+			;;
+		56)
+			url="$1://$2:$3/$4"
+			cat "$bookmarkfile" | grep -iv "^$url " > "$cachedir/bookmarks"
+			mv "$cachedir/bookmarks" "$bookmarkfile"
+			;;
 	esac
 
 	debug "new url: $url"
 }
 
 # Execution
-export LESS='-P Keys\: qgrbosHmM, to see a description run astro -h'
+export LESS='-P Keys\: qgrbosHmMK, to see a description run astro -h'
 
 # First request
 url="${args:-$homepage}"

--- a/less.keys
+++ b/less.keys
@@ -6,4 +6,5 @@ b quit 4
 H quit 5
 m quit 6
 M quit 7
+K quit 8
 


### PR DESCRIPTION
sorry for bugging you with PRs... :grin: 

This adds a new command associated to `K` (uppercase!) to remove the bookmark for the currently visited page - helpful when you push stuff to your bookmarks to read later and want to remove it when read.