### PR TITLE
add u command to jump one path segment up

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To remove a certificate simply delete the `<domain>.crt` and `<domain>.key` file
 - `s` to save the page to a file
 - `m` to add the current page to bookmarks
 - `M` to go to a bookmark
+- `K` to delete the bookmark of the current page
 - `q` to quit
 
 More coming.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To remove a certificate simply delete the `<domain>.crt` and `<domain>.key` file
 ### Key bindings
 
 - `b` to go back one page
+- `u` go one path segment up
 - `o` to open a new URL, you'll be prompted to type it
 - `r` to reload the page
 - `H` to go to the home page

--- a/astro
+++ b/astro
@@ -35,7 +35,6 @@ usage() {
 	echo "Report bugs to: bleemayer@gmail.com"
 	echo "Home page: <https://www.github.com/blmayer/astro/>"
 	echo "General help: <https://www.github.com/blmayer/astro/wiki>"
-	exit
 }
 
 version() {
@@ -94,6 +93,7 @@ cachedir="$cachehome/astro"
 [ -n "$LESSKEY" ] && echo "AE0rR2MtAG8AmDEAcgCYMgBnAJgzAGIAmDQASACYNQBtAJg2AE0AmDcASwCYOAB1AJg5AGUAAHYAAHhFbmQ=" | \
 	base64 -d  > "$LESSKEY"
 
+margin=8
 if [ ! -s "$configfile" ]
 then
 	# Default values
@@ -112,6 +112,8 @@ sty_listt='0'
 EOF
 fi
 
+
+# shellcheck disable=SC1090
 . "$configfile"
 
 mkdir -p "$cachedir"
@@ -405,7 +407,7 @@ EOF
 			;;
 		56)
 			url="$1://$2:$3/$4"
-			cat "$bookmarkfile" | grep -iv "^$url " > "$cachedir/bookmarks"
+			grep -iv "^$url " "$bookmarkfile" > "$cachedir/bookmarks"
 			mv "$cachedir/bookmarks" "$bookmarkfile"
 			;;
 		57)

--- a/astro
+++ b/astro
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+version="0.19.0"
+
 usage() {
-	echo "Astro v0.18.0: Browse the gemini web on the terminal."
+	echo "astro v$version: Browse the gemini web on the terminal."
 	echo ""
 	echo "Usage: astro [url]|[option]"
 	echo ""
@@ -14,6 +16,7 @@ usage() {
 	echo "  g	go to a link"
 	echo "  r	reload current page"
 	echo "  b	go back one page"
+	echo "  u	jump one path segment up"
 	echo "  o	open an address"
 	echo "  s	save current page"
 	echo "  H	go to homepage"
@@ -36,7 +39,7 @@ usage() {
 }
 
 version() {
-	echo "astro 0.18.0"
+	echo "astro $version"
 	echo "Copyright (C) 2021-2023 Brian Mayer."
 	echo "License MIT: MIT License <https://opensource.org/licenses/MIT>"
 	echo "THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,"
@@ -87,7 +90,8 @@ cachedir="$cachehome/astro"
 # m (54): add page to bookmarks
 # M (55): go to a bookmark
 # K (56): remove bookmark for current url
-[ -n "$LESSKEY" ] && echo "AE0rR2MoAG8AmDEAcgCYMgBnAJgzAGIAmDQASACYNQBtAJg2AE0AmDcASwCYOABlAAB2AAB4RW5k" | \
+# u (57): jump one path element up
+[ -n "$LESSKEY" ] && echo "AE0rR2MtAG8AmDEAcgCYMgBnAJgzAGIAmDQASACYNQBtAJg2AE0AmDcASwCYOAB1AJg5AGUAAHYAAHhFbmQ=" | \
 	base64 -d  > "$LESSKEY"
 
 if [ ! -s "$configfile" ]
@@ -404,13 +408,17 @@ EOF
 			cat "$bookmarkfile" | grep -iv "^$url " > "$cachedir/bookmarks"
 			mv "$cachedir/bookmarks" "$bookmarkfile"
 			;;
+		57)
+			newpath=$(echo "/$4" | rev | cut -d'/' -f2- | rev)
+			url="$1://$2:$3/$newpath"
+			;;
 	esac
 
 	debug "new url: $url"
 }
 
 # Execution
-export LESS='-P Keys\: qgrbosHmMK, to see a description run astro -h'
+export LESS='-P Keys\: qgrubosHmMK, to see a description run astro -h'
 
 # First request
 url="${args:-$homepage}"

--- a/less.keys
+++ b/less.keys
@@ -7,4 +7,4 @@ H quit 5
 m quit 6
 M quit 7
 K quit 8
-
+u quit 9


### PR DESCRIPTION
The new `u` command allows you to jump one path segment up, e.g. from `gemini://capsule.tld/log/today` to `gemini://capsule.tld/log/`. This is helpful for some capsules that don't provide a "home" or "back" link.

Additionally some shellcheck warnings were fixed.