### PR TITLE
fix text rendering when preformat identifier is used inline

### DIFF
--- a/astro
+++ b/astro
@@ -177,7 +177,7 @@ typesetgmi() {
 	do
 		line="$(echo "$line" | tr -d '\r')"
 		# shellcheck disable=SC2016
-		echo "$line" | grep -q '```' && pre=$((1 - pre)) && line=""
+		echo "$line" | grep -q '^```' && pre=$((1 - pre)) && line=""
 
 		# Add margins and fold
 		if [ "$pre" = 1 ]


### PR DESCRIPTION
only treat preformat identifier as such when it is positioned at the start of the line 