### PR TITLE
use mimetype to decide if typesetting is needed

### DIFF
--- a/astro
+++ b/astro
@@ -192,7 +192,7 @@ typesetgmi() {
 
 				sty="$sty_linkt"
 				line="$(echo "$sty_linkb$sty_linkt" | sed "s/%linkcount/$linkcount/g")$line"
-				debug "link line: $line"
+				#debug "link line: $line"
 				;;
 			'* '*) sty="$sty_listt" && line="$sty_listb$sty_listt$(echo "$line" | cut -c 2-)";;
 			*) sty="";;
@@ -277,7 +277,7 @@ EOF
 	status="$(echo "$status" | tr -d '\r\n')"
 	meta="$(echo "$meta" | tr -d '\r\n')"
 	sed -i '1d' "$pagefile"
-	debug "response header: $status $meta"
+	debug "response status - meta: $status - $meta"
 
 	# Validate
 	case "$status" in
@@ -376,8 +376,8 @@ EOF
 	esac
 	debug "charset: $charset"
 
-	case ${meta#[0-9][0-9]" "} in
-		*"text/gemini*"|"$meta"|"") typesetgmi ;;
+	case $meta in
+		"text/gemini"* | "") typesetgmi ;;
 		*) cat ;;
 	esac < "$pagefile" | LESSCHARSET="$charset" less -k "$LESSKEY" +k -R
 	code="$?"

--- a/astro
+++ b/astro
@@ -377,7 +377,7 @@ EOF
 	debug "charset: $charset"
 
 	case ${meta#[0-9][0-9]" "} in
-		*"text/gemini*"|"$meta") typesetgmi ;;
+		*"text/gemini*"|"$meta"|"") typesetgmi ;;
 		*) cat ;;
 	esac < "$pagefile" | LESSCHARSET="$charset" less -k "$LESSKEY" +k -R
 	code="$?"

--- a/astro
+++ b/astro
@@ -376,10 +376,9 @@ EOF
 	esac
 	debug "charset: $charset"
 
-	case $4 in
-		*".gmi"|"") typesetgmi ;;
-		*.*) cat ;;
-		*) typesetgmi ;;
+	case $meta in
+		*"text/gemini") typesetgmi ;;
+		*) cat ;;
 	esac < "$pagefile" | LESSCHARSET="$charset" less -k "$LESSKEY" +k -R
 	code="$?"
 	rm "$pagefile"

--- a/astro
+++ b/astro
@@ -376,8 +376,8 @@ EOF
 	esac
 	debug "charset: $charset"
 
-	case $meta in
-		*"text/gemini") typesetgmi ;;
+	case ${meta#[0-9][0-9]" "} in
+		*"text/gemini*"|"$meta") typesetgmi ;;
 		*) cat ;;
 	esac < "$pagefile" | LESSCHARSET="$charset" less -k "$LESSKEY" +k -R
 	code="$?"


### PR DESCRIPTION
When the path portion of the URI contains a dot - for example in the query part like in `geminispace.info/search?test.com` - the page is not handled by `typesetgmi`. Instead of matching the `path` part of the URI we check the mimetype from meta instead.

I'm currently unsure if the dot in a query part should be percent-encoded anyway (quick research lead to ambigous results). At least for now astro does not percent-encode it.