### PR TITLE
fix missing last line when page doesn't end with a new line

### DIFF
--- a/astro
+++ b/astro
@@ -163,7 +163,7 @@ parseurl() {
 }
 
 typesetgmi() {
-	while IFS='' read -r line
+	while IFS='' read -r line || [ -n "$line" ];
 	do
 		line="$(echo "$line" | tr -d '\r')"
 		# shellcheck disable=SC2016


### PR DESCRIPTION
Due to the behaviour of `read` the current implementation will drop the content of the last line of a page if it's not followed by an empty newline.

solution found (it's an interesting read besides that) at: https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line