### PR TITLE
Makefile: install docs and add uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-.PHONY: install
+.PHONY: install uninstall
 
 PREFIX ?= ~/.local
+BINDIR?=$(PREFIX)/bin
+DOCDIR?=$(PREFIX)/share/doc/astro
 
 install:
-	install -m +rx astro -t $(PREFIX)/bin/
+	mkdir -p $(BINDIR) $(DOCDIR)
+	install -m +rx astro -t $(BINDIR)
+	install -m +r README.md -t $(DOCDIR)
+	install -m +r LICENSE -t $(DOCDIR)
 
+uninstall:
+	rm $(BINDIR)/astro
+	rm -rf $(DOCDIR)


### PR DESCRIPTION
extend the Makefile to install README & LICENSE as well and add `uninstall`

requested by a user of the AUR package - i'd like to have this upstream instead of messing around in the PKGBUILD ;)