### PR TITLE
Fixed printf bug

### DIFF
--- a/ereandel
+++ b/ereandel
@@ -264,13 +264,14 @@ typesetgmi() {
 			*) sty='' ;;
 		esac
 
-		# shellcheck disable=SC2059
 		printf -- "%s\n" "$line" | fold -w "$width" -s | while IFS='' read -r txt
 		do
 			printf "%*s" "$margin" ""
 
+			# The '--' here is to make sure the next string is treated as the 
+			# format string, even if $sty begins with a '-'.
 			# shellcheck disable=SC2059
-			printf -- "$sty$txt\n\033[m"
+			printf -- "$sty%s\n\033[m" "$txt"
 		done
 	done
 }


### PR DESCRIPTION
I fixed a bug where `%` symbols in gemtext are interpreted as `printf` escape codes, due to the gemtext content being directly inserted into the `printf` format string. I also removed an unneeded ShellCheck directive.

I can't find in the man pages etc. precisely how arguments work for `printf`. It appears that `--` does what it usually does, in that it says that future arguments should not be treated as option flags, even if they start with `-`. What I'm not sure about is if arguments that start with `-`, but occur *after* the format string, get treated as options by `printf`. Testing on the `printf`s I have at hand (BusyBox's `sh`, GNU coreutils' `printf`), they seem to *not* treat arguments after the format string that start with `-` as options. If this is indeed the standard, universally reliable behaviour, then the `--` in the line
```sh
printf -- "%s\n" "$line" | fold -w "$width" -s | while IFS='' read -r txt
```
can be removed. Due to my uncertainty, I haven't done this in this commit.