### PR TITLE
No info page

### DIFF
--- a/ereandel.en.1
+++ b/ereandel.en.1
@@ -1,4 +1,4 @@
-.TH EREANDEL "1" "November 2023" "ereandel 0.26.0" "User Commands"
+.TH EREANDEL "1" "February 2026" "ereandel 0.26.0" "User Commands"
 .SH NAME
 ereandel \- A Gemini web browser using shell script
 .SH SYNOPSIS

--- a/ereandel.en.1
+++ b/ereandel.en.1
@@ -116,15 +116,3 @@ License MIT: MIT License <https://opensource.org/licenses/MIT>
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-.SH "SEE ALSO"
-The full documentation for
-.B ereandel
-is maintained as a Texinfo manual.  If the
-.B info
-and
-.B ereandel
-programs are properly installed at your site, the command
-.IP
-.B info ereandel
-.PP
-should give you access to the complete manual.


### PR DESCRIPTION
There's a section in the man page about the `info` page for ereandel, but it doesn't have one! I think this was automatically generated by `help2man` and never removed, so I've removed it here. Also updated the last-modified date of the man page.